### PR TITLE
Feat - Multi-year support for time-based entries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -173,13 +173,13 @@ time-butler add entry --project <my_project> --hours 8 --description "Fixed a bu
 - [X] First version of a *okey* project readme
 - [X] Add building instructions
 - [ ] Basic tests
-- [ ] Basic github actions
+- [X] Basic github actions pipeline setup
 - [X] Improve the hour calculation in Day, to take minutes in to account
 - [ ] Update project hours type to float. Will brake existing serializing for current users.
 - [ ] Fix all `clippy` warnings
 - [ ] Read settings (storage path etc) from config files places under /home/user/.conf/time-butler/time-butler.conf
 - [X] Add Target, with status for stored time containers
-- [ ] Verify all the document comments for cli. Make sure they are updated and correct.
+- [X] Verify all the document comments for cli. Make sure they are updated and correct.
 - [ ] Refactor out the butler table functions to a separate file.
 
 **Version 1.1.0**
@@ -189,7 +189,7 @@ time-butler add entry --project <my_project> --hours 8 --description "Fixed a bu
 - [ ] Implement the *modify* command
 - [ ] Removal of week
 - [ ] Add a simple backup function, to store files managed by the butler
-- [ ] Create a verification function for storage of years. If you have week1 in both 2025 and 2024 it has be handled by year. Possible solution to add the year in the struct as well.
+- [X] Create a verification function for storage of years. If you have week1 in both 2025 and 2024 it has be handled by year. Possible solution to add the year in the struct as well.
 - [ ] Add functionality in day, to talk in the lunch time in hours worked. Should be a default value + config
 - [ ] Refactor the Target *todos*
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,14 +44,15 @@ pub enum Commands {
         #[command(subcommand)]
         entity: ReportSubcommands,
     },
+    /// List already reported items
     List {
         /// Project name
         #[arg(short, long)]
         project: Option<String>,
-        /// Week number
+        /// Week number - if multiple weeks exists with same number, all will be listed
         #[arg(short, long)]
         week: Option<String>,
-        /// Month number
+        /// Month number - if multiple months exists with same number, all will be listed
         #[arg(short, long)]
         month: Option<String>,
         /// Display all weeks
@@ -61,6 +62,7 @@ pub enum Commands {
         #[arg(long, action = clap::ArgAction::SetTrue)]
         all_projects: bool,
     },
+    /// Remove a already store item
     Remove {
         /// Project name
         #[command(subcommand)]
@@ -74,6 +76,9 @@ pub enum Commands {
         /// Entry ID
         #[arg(short, long)]
         entry: Option<String>,
+        /// Day date
+        #[arg(short, long)]
+        day: Option<String>,
     },
 
     /// Short Info regarding internal storage
@@ -88,7 +93,7 @@ pub enum Commands {
         /// Target times info
         #[command(subcommand)]
         entity: TargetTimesSubcommands,
-    }
+    },
 }
 
 /// Enum for "add" subcommands
@@ -132,11 +137,13 @@ pub enum AddSubcommands {
 /// Enum for "remove" subcommands
 #[derive(Subcommand)]
 pub enum RemoveSubcommands {
+    /// Remove a project and all its entries
     Project {
         /// Project name
         #[arg(short, long)]
         name: String,
     },
+    /// Remove a specific entry from a project
     Entry {
         /// Project name
         #[arg(long)]
@@ -145,6 +152,7 @@ pub enum RemoveSubcommands {
         #[arg(long)]
         id: Option<String>,
     },
+    /// Remove a specific day from a week
     Day {
         /// Date
         #[arg(long)]
@@ -185,6 +193,9 @@ pub enum ReportSubcommands {
         /// Week number
         #[arg(short, long)]
         number: u32,
+        /// Year number
+        #[arg(short, long)]
+        year: u32,
         /// Report format, valid options are: "json, csv, yaml, html, pdf, text"`
         #[arg(short, long)]
         format: String,
@@ -194,6 +205,9 @@ pub enum ReportSubcommands {
         /// Month number
         #[arg(short, long)]
         number: u32,
+        /// Year number
+        #[arg(short, long)]
+        year: u32,
         /// Report format, valid options are: "json, csv, yaml, html, pdf, text"`
         #[arg(short, long)]
         format: String,
@@ -216,12 +230,18 @@ pub enum TargetTimesSubcommands {
         /// Week number
         #[arg(short, long)]
         number: u32,
+        /// Year number
+        #[arg(short, long)]
+        year: u32,
     },
     /// Set target for the month
     Month {
         /// Month number
         #[arg(short, long)]
         number: u32,
+        /// Year number
+        #[arg(short, long)]
+        year: u32,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,12 @@ mod project;
 mod report;
 mod report_manager;
 mod storage_handler;
-mod week;
 mod target;
+mod week;
 
-use cli::{AddSubcommands, Cli, Commands, RemoveSubcommands, ReportSubcommands, TargetTimesSubcommands};
+use cli::{
+    AddSubcommands, Cli, Commands, RemoveSubcommands, ReportSubcommands, TargetTimesSubcommands,
+};
 use std::process;
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
@@ -133,15 +135,23 @@ fn main() {
                     tracing::info!("Project report generated successfully!");
                 }
             }
-            ReportSubcommands::Week { number, format } => {
+            ReportSubcommands::Week {
+                number,
+                format,
+                year,
+            } => {
                 tracing::debug!("Generating Week report");
-                if butler.week_report(number, &format) {
+                if butler.week_report(number, &format, year) {
                     tracing::info!("Report for week {} generated successfully!", number);
                 }
             }
-            ReportSubcommands::Month { number, format } => {
+            ReportSubcommands::Month {
+                number,
+                format,
+                year,
+            } => {
                 tracing::debug!("Generating Month report");
-                if butler.month_report(number, &format) {
+                if butler.month_report(number, &format, year) {
                     tracing::info!("Report for month {} generated successfully!", number);
                 }
             }
@@ -234,29 +244,52 @@ fn main() {
             }
         },
         Commands::Modify { .. } => todo!(), // all other commands
-        Commands::Info {short } => {
+        Commands::Info { short } => {
             tracing::debug!("Displaying storage info!");
             butler.self_info(short);
-
         }
-        Commands::Targets {entity } => match entity {
-            TargetTimesSubcommands::Week { number } => {
-                tracing::debug!("Displaying target times for week {}", number);
-                if !butler.display_week_target_status(number) {
-                    tracing::error!("Failed to display target times for week {}", number);
+        Commands::Targets { entity } => match entity {
+            TargetTimesSubcommands::Week { number, year } => {
+                tracing::debug!(
+                    "Displaying target times for week {} in year {}",
+                    number,
+                    year
+                );
+                if !butler.display_week_target_status(number, year) {
+                    tracing::error!(
+                        "Failed to display target times for week {} in year {}",
+                        number,
+                        year
+                    );
                 } else {
-                    tracing::info!("Target times for week {} displayed successfully!", number);
+                    tracing::info!(
+                        "Target times for week {} displayed in year {} successfully!",
+                        number,
+                        year
+                    );
                 }
             }
-            TargetTimesSubcommands::Month { number } => {
-                tracing::debug!("Displaying target times for month{}", number);
-                if !butler.display_month_target_status(number) {
-                    tracing::error!("Failed to display target times for week {}", number);
+            TargetTimesSubcommands::Month { number, year } => {
+                tracing::debug!(
+                    "Displaying target times for month{} in year {}",
+                    number,
+                    year
+                );
+                if !butler.display_month_target_status(number, year) {
+                    tracing::error!(
+                        "Failed to display target times for week {} in year {}",
+                        number,
+                        year
+                    );
                 } else {
-                    tracing::info!("Target times for week {} displayed successfully!", number);
+                    tracing::info!(
+                        "Target times for week {} displayed in year {} successfully!",
+                        number,
+                        year
+                    );
                 }
             }
-        }
+        },
     }
 
     if store_data {

--- a/src/week.rs
+++ b/src/week.rs
@@ -17,14 +17,17 @@ pub struct Week {
     number: u32,
     /// Week  entries
     entries: Vec<Day>,
+    /// Year
+    year: i32,
 }
 
 impl Week {
     /// Create a new week
-    pub fn new(number: u32) -> Self {
+    pub fn new(number: u32, year: i32) -> Self {
         Self {
             number,
             entries: Vec::new(),
+            year,
         }
     }
 
@@ -36,6 +39,10 @@ impl Week {
     /// Getter for `entries`
     pub fn entries(&self) -> &Vec<Day> {
         &self.entries
+    }
+
+    pub fn year(&self) -> i32 {
+        self.year
     }
 
     /// Add a new entry to the project


### PR DESCRIPTION
This commit adds year to time entries, which can be entered on different years, such as month and week. The commit solves issue with having multiple entries for same week or month number. In order to do that, the commit updates the week type which brakes back-wards campatibility in serialization.