### PR TITLE
Impr - Separate butler table support functions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,7 +181,7 @@ time-butler add entry --project <my_project> --hours 8 --description "Fixed a bu
 - [X] Read settings (storage path etc) from config file
 - [X] Add Target, with status for stored time containers
 - [X] Verify all the document comments for cli. Make sure they are updated and correct.
-- [ ] Refactor out the butler table functions to a separate file.
+- [X] Refactor out the butler table functions to a separate file.
 - [ ] Implement the *modify* command
 - [X] Add initial pause function to a day, in order to exclude total work hours
 

--- a/src/butler.rs
+++ b/src/butler.rs
@@ -19,6 +19,7 @@ use crate::project::Project;
 use crate::report::ReportFormat;
 use crate::report_manager::ReportManager;
 use crate::storage_handler::StorageHandler;
+use crate::tables;
 use crate::target::{MonthlyTargetStatus, WeeklyTargetStatus};
 use crate::week::Week;
 
@@ -321,7 +322,7 @@ impl Butler {
     pub fn list_specific_project(&self, project_name: &str) {
         for p in &self.projects {
             if p.name() == project_name {
-                let mut table = Self::get_table_entry();
+                let mut table = tables::get_table_entry();
 
                 for e in p.entries() {
                     table.add_row(vec![
@@ -380,7 +381,7 @@ impl Butler {
 
         for (year, week) in weeks_by_year {
             println!("Year: {}", year);
-            let mut table = Self::get_table_day();
+            let mut table = tables::get_table_day();
 
             for d in week.entries() {
                 let start_time = match d.starting_time() {
@@ -428,7 +429,7 @@ impl Butler {
 
         for (year, days) in days_by_year {
             println!("Year: {}", year);
-            let mut table = Self::get_table_day();
+            let mut table = tables::get_table_day();
 
             for d in days {
                 let start_time = match d.starting_time() {
@@ -466,7 +467,7 @@ impl Butler {
                 p.add_entry(entry);
 
                 // Print new entry as confirmation to user
-                Self::print_entry_in_report_table(&entry_clone);
+                tables::print_entry_in_report_table(&entry_clone);
                 return true;
             }
         }
@@ -495,7 +496,7 @@ impl Butler {
                 self.configuration.week_target_hours(),
             );
             // Print the new added day as confirmation to user, quite nice verification
-            Self::print_day_in_report_table(&day);
+            tables::print_day_in_report_table(&day);
             new_week.add_entry(day);
             self.weeks.push(new_week);
             return true;
@@ -523,7 +524,7 @@ impl Butler {
                         let day_cpy = w.get_day_copy(&day.date()).unwrap(); // safe since day exists already
 
                         // Print the new added day as confirmation to user, quite nice verification
-                        Self::print_day_in_report_table(&day_cpy);
+                        tables::print_day_in_report_table(&day_cpy);
                         return true;
                     } else {
                         // Day don't exists in week
@@ -540,7 +541,7 @@ impl Butler {
                         let day_cpy = w.get_day_copy(&new_day_date).unwrap(); // safe since day exists already
 
                         // Print the new added day as confirmation to user, quite nice verification
-                        Self::print_day_in_report_table(&day_cpy);
+                        tables::print_day_in_report_table(&day_cpy);
                         return true;
                     }
                 } else {
@@ -555,7 +556,7 @@ impl Butler {
                         );
 
                         // Print the new added day as confirmation to user, before adding to week and loose ownership
-                        Self::print_day_in_report_table(&day);
+                        tables::print_day_in_report_table(&day);
 
                         new_week.add_entry(day);
                         self.weeks.push(new_week);
@@ -759,7 +760,7 @@ impl Butler {
 
                 let day_cpy = w.get_day_copy(&parsed_date).unwrap(); // safe since we know it exists
 
-                let mut table = Self::get_table_day();
+                let mut table = tables::get_table_day();
 
                 table.add_row(vec![
                     Cell::new(&day_cpy.week().to_string()),
@@ -819,7 +820,7 @@ impl Butler {
         for w in &self.weeks {
             if w.number() == week && w.year() as u32 == year {
                 let status = WeeklyTargetStatus::new(&w, &w.target_hours());
-                let mut table = Self::get_table_target_week();
+                let mut table = tables::get_table_target_week();
                 table.add_row(vec![
                     Cell::new(week),
                     Cell::new(status.target_hours().to_string()),
@@ -879,7 +880,7 @@ impl Butler {
         }
 
         let status = MonthlyTargetStatus::new(&days_vec, &month_target_hours);
-        let mut table = Self::get_table_target_month();
+        let mut table = tables::get_table_target_month();
 
         table.add_row(vec![
             Cell::new(month_number),
@@ -983,121 +984,5 @@ impl Butler {
             }
         }
         weeks
-    }
-
-    /// Internal function to get the table for printing a day
-    fn get_table_day() -> Table {
-        let mut table = Table::new();
-        table.set_content_arrangement(ContentArrangement::Dynamic);
-
-        table.set_header(vec![
-            Cell::new("Week"),
-            Cell::new("Date"),
-            Cell::new("Start time"),
-            Cell::new("End time"),
-            Cell::new("Paused hours"),
-            Cell::new("Hours"),
-            Cell::new("Closed"),
-            Cell::new("Extra info"),
-        ]);
-
-        table
-    }
-
-    /// Internal function to get a table for printing a entry in a project
-    fn get_table_entry() -> Table {
-        let mut table = Table::new();
-        table.set_content_arrangement(ContentArrangement::Dynamic);
-
-        table.set_header(vec![
-            Cell::new("Project"),
-            Cell::new("Description"),
-            Cell::new("Hours"),
-            Cell::new("Created"),
-            Cell::new("ID"),
-        ]);
-
-        table
-    }
-
-    /// Internal function to get a table for printing week target status
-    fn get_table_target_week() -> Table {
-        let mut table = Table::new();
-        table.set_content_arrangement(ContentArrangement::Dynamic);
-
-        table.set_header(vec![
-            Cell::new("Week"),
-            Cell::new("Target hours"),
-            Cell::new("Current reported hours"),
-            Cell::new("Percentage done"),
-            Cell::new("Target status"),
-            Cell::new("Hours remaining"),
-            Cell::new("Hours overtime"),
-            Cell::new("Target hours set method"),
-        ]);
-
-        table
-    }
-
-    /// Internal function to get a table for printing week target status
-    fn get_table_target_month() -> Table {
-        let mut table = Table::new();
-        table.set_content_arrangement(ContentArrangement::Dynamic);
-
-        table.set_header(vec![
-            Cell::new("Month"),
-            Cell::new("Target hours"),
-            Cell::new("Current reported hours"),
-            Cell::new("Percentage done"),
-            Cell::new("Target status"),
-            Cell::new("Hours remaining"),
-            Cell::new("Hours overtime"),
-            Cell::new("Target hours set method"),
-        ]);
-
-        table
-    }
-
-    // Internal function to print a single day, in report table format
-    fn print_day_in_report_table(day: &Day) {
-        let mut table = Self::get_table_day();
-
-        let start_time = match day.starting_time() {
-            Some(st) => st.to_string(),
-            None => "N/A".to_string(),
-        };
-
-        let end_time = match day.ending_time() {
-            Some(et) => et.to_string(),
-            None => "N/A".to_string(),
-        };
-
-        table.add_row(vec![
-            Cell::new(&day.week().to_string()),
-            Cell::new(&day.date().to_string()),
-            Cell::new(start_time),
-            Cell::new(end_time),
-            Cell::new(&day.hours_paused().to_string()),
-            Cell::new(&day.hours().to_string()),
-            Cell::new(&day.closed().to_string()),
-            Cell::new(&day.extra_info()),
-        ]);
-
-        println!("{}", table);
-    }
-
-    // Internal function to print a single entry, in report table format
-    fn print_entry_in_report_table(entry: &Entry) {
-        let mut table = Self::get_table_entry();
-
-        table.add_row(vec![
-            Cell::new("Project"),
-            Cell::new(entry.description()),
-            Cell::new(&entry.hours().to_string()),
-            Cell::new(&entry.created().to_string()),
-            Cell::new(&entry.id().to_string()),
-        ]);
-
-        println!("{}", table);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod project;
 mod report;
 mod report_manager;
 mod storage_handler;
+mod tables;
 mod target;
 mod week;
 

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -1,0 +1,128 @@
+/*
+ * File: tables.rs
+ * Description: The definition of the display tables for time items used by the butler.
+ * Author: dherslof
+ * Created: 27-04-2026
+ * License: MIT
+ */
+
+use comfy_table::{Cell, ContentArrangement, Table};
+
+use crate::day::Day;
+use crate::entry::Entry;
+
+/// Internal function to get the table for printing a day
+pub fn get_table_day() -> Table {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    table.set_header(vec![
+        Cell::new("Week"),
+        Cell::new("Date"),
+        Cell::new("Start time"),
+        Cell::new("End time"),
+        Cell::new("Paused hours"),
+        Cell::new("Hours"),
+        Cell::new("Closed"),
+        Cell::new("Extra info"),
+    ]);
+
+    table
+}
+
+/// Internal function to get a table for printing a entry in a project
+pub fn get_table_entry() -> Table {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    table.set_header(vec![
+        Cell::new("Project"),
+        Cell::new("Description"),
+        Cell::new("Hours"),
+        Cell::new("Created"),
+        Cell::new("ID"),
+    ]);
+
+    table
+}
+
+/// Internal function to get a table for printing week target status
+pub fn get_table_target_week() -> Table {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    table.set_header(vec![
+        Cell::new("Week"),
+        Cell::new("Target hours"),
+        Cell::new("Current reported hours"),
+        Cell::new("Percentage done"),
+        Cell::new("Target status"),
+        Cell::new("Hours remaining"),
+        Cell::new("Hours overtime"),
+        Cell::new("Target hours set method"),
+    ]);
+
+    table
+}
+
+/// Internal function to get a table for printing week target status
+pub fn get_table_target_month() -> Table {
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+
+    table.set_header(vec![
+        Cell::new("Month"),
+        Cell::new("Target hours"),
+        Cell::new("Current reported hours"),
+        Cell::new("Percentage done"),
+        Cell::new("Target status"),
+        Cell::new("Hours remaining"),
+        Cell::new("Hours overtime"),
+        Cell::new("Target hours set method"),
+    ]);
+
+    table
+}
+
+// Internal function to print a single day, in report table format
+pub fn print_day_in_report_table(day: &Day) {
+    let mut table = get_table_day();
+
+    let start_time = match day.starting_time() {
+        Some(st) => st.to_string(),
+        None => "N/A".to_string(),
+    };
+
+    let end_time = match day.ending_time() {
+        Some(et) => et.to_string(),
+        None => "N/A".to_string(),
+    };
+
+    table.add_row(vec![
+        Cell::new(&day.week().to_string()),
+        Cell::new(&day.date().to_string()),
+        Cell::new(start_time),
+        Cell::new(end_time),
+        Cell::new(&day.hours_paused().to_string()),
+        Cell::new(&day.hours().to_string()),
+        Cell::new(&day.closed().to_string()),
+        Cell::new(&day.extra_info()),
+    ]);
+
+    println!("{}", table);
+}
+
+// Internal function to print a single entry, in report table format
+pub fn print_entry_in_report_table(entry: &Entry) {
+    let mut table = get_table_entry();
+
+    table.add_row(vec![
+        Cell::new("Project"),
+        Cell::new(entry.description()),
+        Cell::new(&entry.hours().to_string()),
+        Cell::new(&entry.created().to_string()),
+        Cell::new(&entry.id().to_string()),
+    ]);
+
+    println!("{}", table);
+}


### PR DESCRIPTION
This commit moves the support functions related to printing tables (formatted data) from the butler main implementation to a new support file.

Reason for this is to reduce the scope om the butler main implementation file in order to improve maintainability and readability.