### PR TITLE
Impr - Remove unnecessary return statements

### DIFF
--- a/src/backup_organizer.rs
+++ b/src/backup_organizer.rs
@@ -95,7 +95,7 @@ impl BackupOrganizer {
             self.save_state()?;
         }
 
-        return Ok(());
+        Ok(())
     }
 
     /// Create the backup directory if it does not exist

--- a/src/butler.rs
+++ b/src/butler.rs
@@ -64,10 +64,10 @@ impl Butler {
 
         // Normalize and match the response
         match input.trim().to_lowercase().as_str() {
-            "yes" | "y" => return true,
+            "yes" | "y" => true,
             _ => {
                 tracing::warn!("Not confirmed by user");
-                return false;
+                false
             }
         }
     }
@@ -144,7 +144,7 @@ impl Butler {
         tracing::debug!("Project will be stored with ID: {}", project.id());
         self.projects.push(project);
 
-        return true;
+        true
     }
 
     /// Create a new project report
@@ -186,7 +186,7 @@ impl Butler {
         }
 
         tracing::error!("Project with name {} not found", project_name);
-        return false;
+        false
     }
 
     /// Create a new week report
@@ -233,7 +233,7 @@ impl Butler {
             week_number,
             year
         );
-        return false;
+        false
     }
 
     pub fn month_report(&self, month_number: u32, format: &str, year: u32) -> bool {
@@ -291,7 +291,7 @@ impl Butler {
                 }
             };
 
-        return generation_result;
+        generation_result
     }
 
     /// List all projects
@@ -476,7 +476,7 @@ impl Butler {
             "Project with name {} not found, unable to add entry",
             project_name
         );
-        return false;
+        false
     }
 
     /// Add new day to a week
@@ -567,7 +567,7 @@ impl Butler {
                 }
             }
         }
-        return false;
+        false
     }
 
     /// Save the butler data to storage, in bin format
@@ -602,7 +602,7 @@ impl Butler {
             self.configuration.periodic_backup_interval(),
         );
 
-        return true;
+        true
     }
 
     pub fn force_backup(&self) -> bool {
@@ -610,11 +610,11 @@ impl Butler {
         match self.storage_handler.do_backup_now() {
             Ok(_) => {
                 tracing::info!("Backup completed successfully");
-                return true;
+                true
             }
             Err(e) => {
                 tracing::error!("Backup failed: {}", e);
-                return false;
+                false
             }
         }
     }
@@ -639,14 +639,14 @@ impl Butler {
             )) {
                 self.projects.remove(index);
                 tracing::debug!("Project {}, removed", project_name);
-                return true;
+                true
             } else {
                 tracing::info!("Confirmation not given, aborting");
-                return false;
+                false
             }
         } else {
             tracing::warn!("Project with name {} not found", project_name);
-            return false;
+            false
         }
     }
 
@@ -722,7 +722,7 @@ impl Butler {
             }
         }
         tracing::warn!("Project with name {} not found", project);
-        return false;
+        false
     }
 
     pub fn remove_day(&mut self, week: u32, date: String) -> bool {
@@ -808,7 +808,7 @@ impl Butler {
             week,
             year
         );
-        return false;
+        false
     }
 
     pub fn display_week_target_status(&self, week: u32, year: u32) -> bool {
@@ -846,7 +846,7 @@ impl Butler {
         }
 
         tracing::warn!("Week with number {} not found", week);
-        return false;
+        false
     }
 
     pub fn display_month_target_status(&self, month_number: u32, year: u32) -> bool {
@@ -902,7 +902,7 @@ impl Butler {
         ]);
 
         println!("{}", table);
-        return true;
+        true
     }
 
     pub fn dump_configuration_to_terminal(&self, configuration_file_path: String) {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -48,7 +48,7 @@ impl Entry {
             None => "",
         };
 
-        return return_value;
+        return_value
     }
 
     /// Getter for `created`

--- a/src/project.rs
+++ b/src/project.rs
@@ -66,9 +66,9 @@ impl Project {
     pub fn remove_listed_entry(&mut self, entry_id: &Uuid) -> bool {
         if self.entry_exists(entry_id) {
             self.entries.retain(|e| e.id() != entry_id);
-            return true;
+            true
         } else {
-            return false;
+            false
         }
     }
 
@@ -79,7 +79,7 @@ impl Project {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// Return a copy of an entry
@@ -89,7 +89,7 @@ impl Project {
                 return Some(e.clone());
             }
         }
-        return None;
+        None
     }
 }
 

--- a/src/report_manager.rs
+++ b/src/report_manager.rs
@@ -192,7 +192,7 @@ impl ReportManager {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
     /// Internal function to write a YAML project report file
@@ -217,7 +217,7 @@ impl ReportManager {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
     /// Internal function to write an HTML project report file
@@ -489,7 +489,7 @@ impl ReportManager {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
     /// Internal function to write a YAML week report file
@@ -546,7 +546,7 @@ impl ReportManager {
             }
         }
 
-        return Ok(());
+        Ok(())
     }
 
     /// Internal function to write an HTML week report file
@@ -859,7 +859,7 @@ impl ReportManager {
                 unimplemented!(); //TODO: Implement this
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     fn write_yaml_month_report(
@@ -950,7 +950,7 @@ impl ReportManager {
                 unimplemented!(); //TODO: Implement this
             }
         }
-        return Ok(());
+        Ok(())
     }
 
     fn write_html_month_report(

--- a/src/storage_handler.rs
+++ b/src/storage_handler.rs
@@ -106,7 +106,7 @@ impl StorageHandler {
             }
         };
 
-        return Some(projects);
+        Some(projects)
     }
 
     /// Store projects to storage
@@ -189,7 +189,7 @@ impl StorageHandler {
             }
         };
 
-        return Some(weeks);
+        Some(weeks)
     }
 
     /// Store weeks to storage

--- a/src/week.rs
+++ b/src/week.rs
@@ -70,7 +70,7 @@ impl Week {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// Overloaded function. Check if a day exists in the week based on NaiveDate
@@ -80,7 +80,7 @@ impl Week {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     /// Modify data for a specific day in the vector
@@ -108,10 +108,10 @@ impl Week {
                 day.set_extra_info(entry.extra_info().to_string());
             }
 
-            return true;
+            true
         } else {
             // Day not found
-            return false;
+            false
         }
     }
 
@@ -122,16 +122,16 @@ impl Week {
                 return Some(d.clone());
             }
         }
-        return None;
+        None
     }
 
     /// Remove Day from the week
     pub fn remove_listed_day(&mut self, date: &NaiveDate) -> bool {
         if self.exist(date) {
             self.entries.retain(|d| d.date() != *date);
-            return true;
+            true
         } else {
-            return false;
+            false
         }
     }
 }


### PR DESCRIPTION
This commits removes unnecessary return statements in functions highlighted by clippy. Same warning is handled across multiple files.