### PR TITLE
Impr - Fix clippy warnings for target.rs

### DIFF
--- a/src/config_reader.rs
+++ b/src/config_reader.rs
@@ -6,7 +6,6 @@
  * License: MIT
  */
 
-use serde_json;
 use std::fs;
 use std::io::Write;
 use std::path::Path;

--- a/src/target.rs
+++ b/src/target.rs
@@ -102,8 +102,6 @@ impl WeeklyTargetStatus {
             TargetStatus::Reached
         } else if percentage > K_100_PERCENT {
             TargetStatus::OverReached
-        } else if percentage < K_100_PERCENT && percentage > 0 {
-            TargetStatus::NotReached
         } else {
             TargetStatus::NotReached
         };
@@ -188,8 +186,6 @@ impl MonthlyTargetStatus {
             TargetStatus::Reached
         } else if percentage > K_100_PERCENT {
             TargetStatus::OverReached
-        } else if percentage < K_100_PERCENT && percentage > 0 {
-            TargetStatus::NotReached
         } else {
             TargetStatus::NotReached
         };


### PR DESCRIPTION
This commit attends and solves the clippy warnings for the file target.rs.

It also attends the only warning for config_readers.rs since it was so small.