### PR TITLE
Impr - Project entry hours data type f32

### DIFF
--- a/src/butler.rs
+++ b/src/butler.rs
@@ -467,7 +467,7 @@ impl Butler {
                 p.add_entry(entry);
 
                 // Print new entry as confirmation to user
-                tables::print_entry_in_report_table(&entry_clone);
+                tables::print_entry_in_report_table(&entry_clone, p.name());
                 return true;
             }
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,7 +129,7 @@ pub enum AddSubcommands {
         project: String,
         /// Hours worked
         #[arg(long)]
-        hours: u32,
+        hours: Option<String>,
         /// Description of the work done
         #[arg(long)]
         description: String,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Entry {
     /// Hours logged
-    hours: u32,
+    hours: f32,
     /// Description of the work done
     description: Option<String>,
     /// Timestamp of when the entry was created
@@ -27,7 +27,7 @@ pub struct Entry {
 /// Implementation for Entry functionality
 impl Entry {
     /// Create a new Entry
-    pub fn new(hours: u32, description: Option<String>) -> Self {
+    pub fn new(hours: f32, description: Option<String>) -> Self {
         Self {
             hours,
             description,
@@ -37,7 +37,7 @@ impl Entry {
     }
 
     /// Getter for `hours`
-    pub fn hours(&self) -> u32 {
+    pub fn hours(&self) -> f32 {
         self.hours
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,16 @@ fn main() {
                 description,
             } => {
                 tracing::debug!("Adding new entry");
-                let e = entry::Entry::new(hours, Some(description));
+                let hours_f32 = match hours {
+                    Some(ref s) => s.parse::<f32>().unwrap_or(0.0),
+                    None => 0.0,
+                };
+
+                if hours_f32 <= 0.0 {
+                    tracing::error!("Invalid hours provided: {} [{} parsed value]. You can't report 0 or negative hours on a project.", hours.unwrap(), hours_f32);
+                }
+
+                let e = entry::Entry::new(hours_f32, Some(description));
                 if butler.add_entry(&project, e) {
                     tracing::info!("Entry added successfully!");
                     store_data = true;

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -113,11 +113,11 @@ pub fn print_day_in_report_table(day: &Day) {
 }
 
 // Internal function to print a single entry, in report table format
-pub fn print_entry_in_report_table(entry: &Entry) {
+pub fn print_entry_in_report_table(entry: &Entry, project_name: &str) {
     let mut table = get_table_entry();
 
     table.add_row(vec![
-        Cell::new("Project"),
+        Cell::new(project_name),
         Cell::new(entry.description()),
         Cell::new(entry.hours().to_string()),
         Cell::new(entry.created().to_string()),


### PR DESCRIPTION
This commit changes the data type of the entry class hours to f32 instead of u32. The change improve details in the time reporting on projects.

The commit breaks backwards backwards compatibility of reading stored project files.