### PR TITLE
Impr - remove wrong error msg for non linux OS

### DIFF
--- a/src/storage_handler.rs
+++ b/src/storage_handler.rs
@@ -218,7 +218,7 @@ impl StorageHandler {
     fn init(&mut self) {
         tracing::debug!("Initializing storage handler");
         if cfg!(not(target_os = "linux")) {
-            tracing::error!("Time-butler is only supported on Linux");
+            tracing::warn!("Non Linux OS detected. Time-butler is developed on and for Linux. Other OSes are not maintained at the same level. You may encounter unknown issues.");
         }
 
         // Todo: Check if a configuration file exists, if not set default paths


### PR DESCRIPTION
This commit changes the error message printed for non linux OSes to a warning instead since it's not an error. The butler is tested on windows and work as expected. However, it's still a warning since windows isn't supported in the same way as linux.