### PR TITLE
Feat - Add extra storage file overwrite protection

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -184,7 +184,7 @@ time-butler add entry --project <my_project> --hours 8 --description "Fixed a bu
 - [X] Refactor out the butler table functions to a separate file.
 - [ ] Implement the *modify* command
 - [X] Add initial pause function to a day, in order to exclude total work hours
-- [ ] Implement storage file version check in order to safe-guard reported time from being overwritten or corrupted.
+- [X] Implement storage file version check in order to safe-guard reported time from being overwritten or corrupted.
 
 **Version 1.1.0**
 - [ ] Full Implement the *info* command.

--- a/src/butler.rs
+++ b/src/butler.rs
@@ -21,6 +21,8 @@ use crate::report_manager::ReportManager;
 use crate::storage_handler::StorageHandler;
 use crate::tables;
 use crate::target::{MonthlyTargetStatus, WeeklyTargetStatus};
+use crate::version_info;
+use crate::version_manager::{VersionCompatibility, VersionManager};
 use crate::week::Week;
 
 /// Butler struct - Main star of the show
@@ -35,6 +37,8 @@ pub struct Butler {
     storage_handler: StorageHandler,
     /// Configuration
     configuration: AppConfiguration,
+    // Version information
+    version_mgnr: VersionManager,
 }
 
 /// Implementation of the functionality for the Butler
@@ -47,10 +51,11 @@ impl Butler {
             report_mngr: ReportManager::new(),
             storage_handler,
             configuration,
+            version_mgnr: VersionManager::new(version_info::VersionInfo::new()),
         }
     }
 
-    /// Internal function for prompting user for confirmation. Used in interactive mode
+    /// Internal function for prompting user for confirmation.
     fn prompt_user_confirmation(question: &str) -> bool {
         let promt = format!("{} [y/N]: ", question);
         print!("{}", promt);
@@ -89,6 +94,76 @@ impl Butler {
         // Update the file paths based on configuratoin
         self.storage_handler
             .set_paths_from_config(&self.configuration);
+
+        self.version_mgnr
+            .set_loaded_storage_metadata(self.storage_handler.load_metadata());
+
+        let storage_compatibility = self.version_mgnr.is_compatible();
+        tracing::debug!(
+            "Butler versions: app version: {}, storage file version: {}",
+            self.version_mgnr.get_version().get_app_version(),
+            self.version_mgnr.get_version().get_storage_file_version()
+        );
+
+        // Check storage compatibility and decide how to proceed based on configuration and user confirmation.
+        // The loading of files don't do so much if failed, but we can fail fast instead of waiting to the writing part.
+
+        match storage_compatibility {
+            VersionCompatibility::Compatible => {
+                tracing::debug!(
+                    "Storage file version is compatible with current application version"
+                );
+            }
+            VersionCompatibility::Incompatible(msg) => {
+                tracing::error!(
+                    "Storage file version is incompatible with current application version: {}",
+                    msg
+                );
+
+                if self
+                    .configuration
+                    .always_force_halt_on_version_incompatibility()
+                {
+                    tracing::info!("Configuration is set to always force halt on version incompatibility, aborting initialization to prevent potential data loss or corruption");
+                    return;
+                }
+
+                // Ask confirmation to user
+                if !Self::prompt_user_confirmation("Storage file version is incompatible with current application version. Do you want to proceed? This may lead to data loss or corruption if the incompatibility is due to breaking changes in the storage file format.") {
+                     tracing::info!("User chose not to proceed, aborting initialization to prevent potential data loss or corruption");
+                  return;
+                  } else {
+                    tracing::warn!("User chose to proceed despite version incompatibility. Forcing a backup of storage as a precautionary measure before continuing.");
+                    self.version_mgnr.set_override_on_incompatibility(true);
+                     match self.storage_handler.do_backup_now() {
+                           Ok(_) => tracing::info!("Backup completed successfully"),
+                           Err(e) => tracing::error!("Backup failed: {}", e),
+                     }
+                  }
+                tracing::warn!("Proceeding with initialization despite version incompatibility.");
+            }
+            VersionCompatibility::Unknown => {
+                tracing::warn!(
+                    "Storage file version compatibility is unknown, no metadata loaded."
+                );
+                let metadata_write_res = match self
+                    .storage_handler
+                    .write_metadata(&self.version_mgnr.metadata())
+                {
+                    Ok(_) => true,
+                    Err(e) => {
+                        tracing::error!("Failed to write metadata to storage: {}", e);
+                        false
+                    }
+                };
+
+                if metadata_write_res {
+                    tracing::debug!("New metadata file written to storage successfully");
+                } else {
+                    tracing::error!("Failed to create new metadata file to storage");
+                }
+            }
+        }
 
         // Load projects from storage
         if let Some(projects) = self.storage_handler.load_projects() {
@@ -301,6 +376,11 @@ impl Butler {
 
     /// List all projects
     pub fn list_all_projects(&self) {
+        if self.projects.is_empty() {
+            tracing::warn!("No projects stored, unable to list projects");
+            return;
+        }
+
         let mut table = Table::new();
         table.set_content_arrangement(ContentArrangement::Dynamic);
 
@@ -578,6 +658,11 @@ impl Butler {
     /// Save the butler data to storage, in bin format
     pub fn save(&self) -> bool {
         tracing::debug!("Saving data to storage");
+
+        if !self.version_mgnr.ok_to_save_files() {
+            tracing::error!("Not allowed to save files due to version incompatibility. Force override is not enabled");
+            return false;
+        }
 
         let project_storage_result =
             match self.storage_handler.store_projects(self.projects.clone()) {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,9 +14,9 @@ use clap::{Parser, Subcommand};
     name = env!("CARGO_PKG_NAME"),         // Package name from Cargo.toml
     version = env!("CARGO_PKG_VERSION"),   // Version from Cargo.toml
     about = env!("CARGO_PKG_DESCRIPTION"), // Description from Cargo.toml
-    long_about = "A tool to report time on different projects. This can be done by two ways from the CLI, interactive and direct."
+    long_about = "A time report tool that allows users to track and report their working hours in different ways. Easy and flexible direct from the command line"
 )]
-#[command(about = "A tool to report time on different projects", long_about = None)]
+#[command(about = "A time reporting tool", long_about = None)]
 pub struct Cli {
     /// Command to be selected
     #[command(subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct AppConfiguration {
     file_paths: FilePathsConfig,
     targets: TargetsConfig,
     backup: BackupConfig,
+    version: VersionConfiguration,
 }
 
 impl AppConfiguration {
@@ -59,6 +60,10 @@ impl AppConfiguration {
 
     pub fn override_existing_backup(&self) -> bool {
         self.backup.override_existing_backup
+    }
+
+    pub fn always_force_halt_on_version_incompatibility(&self) -> bool {
+        self.version.always_force_halt_on_version_incompatibility
     }
 
     pub fn get_as_string(&self) -> String {
@@ -109,6 +114,10 @@ impl AppConfiguration {
             "  periodic-backup-override: {}\n",
             self.backup.override_existing_backup
         ));
+        out.push_str(&format!(
+            "  always-force-halt-on-version-incompatibility: {}\n",
+            self.version.always_force_halt_on_version_incompatibility
+        ));
         out
     }
 }
@@ -126,7 +135,7 @@ impl AppConfiguration {
                 "{}/.local/time-butler/.app_storage/week_data.bin",
                 user_home
             ),
-            report_directory: format!("{}/.local/time-butler/generated_reports", user_home),
+            report_directory: format!("{}/.local/time-butler/generated-reports", user_home),
             backups_directory: format!("{}/.local/time-butler/backups", user_home),
         };
         let targets = TargetsConfig {
@@ -139,10 +148,14 @@ impl AppConfiguration {
             periodic_backup_interval_days: 14,
             override_existing_backup: true,
         };
+        let version = VersionConfiguration {
+            always_force_halt_on_version_incompatibility: true,
+        };
         Self {
             file_paths,
             targets,
             backup,
+            version,
         }
     }
 }
@@ -187,4 +200,12 @@ pub struct BackupConfig {
     /// Target hours for the week
     #[serde(rename = "periodic-backup-override")]
     pub override_existing_backup: bool,
+}
+
+/// Version configuration struct
+#[derive(Serialize, Deserialize, Clone)]
+pub struct VersionConfiguration {
+    /// Force halt on version incompatibility
+    #[serde(rename = "always-force-halt-on-version-incompatibility")]
+    pub always_force_halt_on_version_incompatibility: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,8 @@ mod report_manager;
 mod storage_handler;
 mod tables;
 mod target;
+mod version_info;
+mod version_manager;
 mod week;
 
 use cli::{

--- a/src/storage_handler.rs
+++ b/src/storage_handler.rs
@@ -12,9 +12,12 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
+use serde::{Deserialize, Serialize};
+
 use crate::backup_organizer::BackupOrganizer;
 use crate::config::AppConfiguration;
 use crate::project::Project;
+use crate::version_info::FileStorageMetadata;
 use crate::week::Week;
 
 // Constants for base paths
@@ -24,6 +27,13 @@ const REPORT_DIR: &str = "generated-reports";
 const PROJECT_DATA_FILE: &str = "prj_data.bin";
 const WEEK_DATA_FILE: &str = "week_data.bin";
 const BACKUP_DIR: &str = ".backups";
+const STORAGE_METADATA_FILE: &str = "metadata.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct VersionInformationWrapper {
+    #[serde(rename = "VersionInformation")]
+    version_information: FileStorageMetadata,
+}
 
 /// The storage handler struct
 pub struct StorageHandler {
@@ -325,5 +335,55 @@ impl StorageHandler {
             backup_duration_interval,
             Some(false),
         )
+    }
+
+    pub fn load_metadata(&self) -> Option<FileStorageMetadata> {
+        let metadata_file = format!(
+            "{}/{}/{}",
+            self.storage_dir, STORAGE_DIR, STORAGE_METADATA_FILE
+        );
+        tracing::debug!("Loading storage metadata from file: {}", metadata_file);
+        if fs::metadata(&metadata_file).is_err() {
+            tracing::error!(
+                "File {} does not exist - OK if running for first time or no metadata stored",
+                metadata_file
+            );
+            return None;
+        }
+
+        let mut file = fs::File::open(metadata_file)
+            .map_err(|e| io::Error::other(format!("Error opening file: {}", e)))
+            .ok()?;
+
+        let mut json = String::new();
+        file.read_to_string(&mut json).ok()?;
+
+        let metadata_wrapper: VersionInformationWrapper = match serde_json::from_str(&json) {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                tracing::error!("Error deserializing metadata json: {}", e);
+                return None;
+            }
+        };
+
+        Some(metadata_wrapper.version_information)
+    }
+
+    pub fn write_metadata(
+        &self,
+        metadata: &FileStorageMetadata,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let metadata_wrapper = VersionInformationWrapper {
+            version_information: metadata.clone(),
+        };
+        let json = serde_json::to_string_pretty(&metadata_wrapper)?;
+        let path_str = format!(
+            "{}/{}/{}",
+            self.storage_dir, STORAGE_DIR, STORAGE_METADATA_FILE
+        );
+        let path = Path::new(&path_str);
+        let mut file = fs::File::create(path)?;
+        file.write_all(json.as_bytes())?;
+        Ok(())
     }
 }

--- a/src/version_info.rs
+++ b/src/version_info.rs
@@ -1,0 +1,60 @@
+/*
+ * File: version_info.rs
+ * Description: The definition of the version information for the time-butler.
+ * Author: dherslof
+ * Created: 18-05-2026
+ * License: MIT
+ */
+
+use serde::{Deserialize, Serialize};
+
+/*
+   Note: Time-butler has two types of versioning:
+   1. Application Version: This is the version of the time-butler application itself, which is defined in the Cargo.toml file. It follows semantic versioning
+   2. Storage File Version: This is the version of the storage file format. It is derived from the application version, but only includes the major version number (the first part of the semantic version). This allows for backward compatibility in storage file formats, as long as there are no breaking changes in the major version.
+*/
+
+/// Struct to hold version information
+#[derive(Debug, Clone)]
+pub struct VersionInfo {
+    /// The version number of the application
+    version: String,
+    /// The version of the storage file format
+    storage_file_version: String,
+}
+
+impl VersionInfo {
+    /// Create a new VersionInfo instance with the current version info from the toml file
+    pub fn new() -> Self {
+        VersionInfo {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            storage_file_version: env!("CARGO_PKG_VERSION")
+                .split('.')
+                .next()
+                .unwrap_or("")
+                .to_string(),
+        }
+    }
+
+    /// Get the main application version
+    pub fn get_app_version(&self) -> String {
+        self.version.clone()
+    }
+
+    /// Get the storage file version
+    pub fn get_storage_file_version(&self) -> String {
+        self.storage_file_version.clone()
+    }
+
+    pub fn as_metadata(&self) -> FileStorageMetadata {
+        FileStorageMetadata {
+            storage_file_version: self.storage_file_version.clone(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FileStorageMetadata {
+    /// The version of the storage file format
+    pub storage_file_version: String,
+}

--- a/src/version_manager.rs
+++ b/src/version_manager.rs
@@ -1,0 +1,89 @@
+/*
+ * File: version_manager.rs
+ * Description: Manages version information and compatibility
+ * Author: dherslof
+ * Created: 18-05-2026
+ * License: MIT
+ */
+
+use crate::version_info::FileStorageMetadata;
+use crate::version_info::VersionInfo;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionCompatibility {
+    Compatible,
+    Incompatible(String), // Contains a message about the incompatibility
+    Unknown,              // When no metadata is loaded
+}
+
+pub struct VersionManager {
+    /// The current version of the application
+    current_version: VersionInfo,
+    /// The storage metadata
+    loaded_storage_metadata: Option<FileStorageMetadata>,
+    /// Campatibility status of the loaded storage file
+    storage_compatibility: VersionCompatibility,
+    override_on_incompatibility: bool,
+}
+
+impl VersionManager {
+    /// Create a new VersionManager instance
+    pub fn new(version_info: VersionInfo) -> Self {
+        VersionManager {
+            current_version: version_info,
+            loaded_storage_metadata: None,
+            storage_compatibility: VersionCompatibility::Unknown,
+            override_on_incompatibility: false,
+        }
+    }
+
+    pub fn ok_to_save_files(&self) -> bool {
+        (self.storage_compatibility == VersionCompatibility::Compatible)
+            || (self.storage_compatibility == VersionCompatibility::Unknown)
+            || self.override_on_incompatibility
+    }
+
+    pub fn set_override_on_incompatibility(&mut self, override_on_incompatibility: bool) {
+        self.override_on_incompatibility = override_on_incompatibility;
+    }
+
+    pub fn set_loaded_storage_metadata(&mut self, metadata: Option<FileStorageMetadata>) {
+        self.loaded_storage_metadata = metadata;
+    }
+
+    pub fn is_compatible(&mut self) -> VersionCompatibility {
+        // Consider compatible if the storage file version matches the current application's storage file version
+        match &self.loaded_storage_metadata {
+            Some(metadata) => {
+                if metadata.storage_file_version == self.current_version.get_storage_file_version()
+                {
+                    self.storage_compatibility = VersionCompatibility::Compatible;
+                    VersionCompatibility::Compatible
+                } else {
+                    self.storage_compatibility = VersionCompatibility::Incompatible(format!(
+                        "Incompatible storage file version: {}. Expected: {}",
+                        metadata.storage_file_version,
+                        self.current_version.get_storage_file_version()
+                    ));
+                    VersionCompatibility::Incompatible(format!(
+                        "Incompatible storage file version: {}. Expected: {}",
+                        metadata.storage_file_version,
+                        self.current_version.get_storage_file_version()
+                    ))
+                }
+            }
+            None => {
+                self.storage_compatibility = VersionCompatibility::Unknown;
+                VersionCompatibility::Unknown // If no metadata is loaded, we cannot determine compatibility
+            }
+        }
+    }
+
+    pub fn metadata(&self) -> FileStorageMetadata {
+        self.current_version.as_metadata()
+    }
+
+    pub fn get_version(&self) -> VersionInfo {
+        self.current_version.clone()
+    }
+}


### PR DESCRIPTION
This commit introduces file storage version based on the applicaiton major version. This is stored as meta-data and save-guards the storage files for being overwriten by a different serializing structure.

The user will still be able to force it manually, but in that case a backup is done to save older data.